### PR TITLE
won't remove acf on cat endpoint and isset for titles and acf

### DIFF
--- a/src/JsonFormatter.php
+++ b/src/JsonFormatter.php
@@ -12,9 +12,9 @@ class JsonFormatter
     ];
 
     public function register() {
-    add_filter( 'rest_post_dispatch', [ $this, 'remove_unused_images' ] );
-    add_filter( 'rest_post_dispatch', [ $this, 'fix_titles' ] );
-    add_filter( 'rest_prepare_category', [ $this, 'remove_acf_from_embedded_categories' ]);
+        add_filter( 'rest_post_dispatch', [ $this, 'remove_unused_images' ] );
+        add_filter( 'rest_post_dispatch', [ $this, 'fix_titles' ] );
+        add_filter( 'rest_prepare_category', [ $this, 'remove_acf_from_embedded_categories' ]);
     }
 
     public function remove_acf_from_embedded_categories($response) {


### PR DESCRIPTION
1. Only unsets the acf of categories if not a category endpoint

2. title and acf only exist first time hook is called, so check they exist (this means the wp patch is redundant and will be removed)